### PR TITLE
Move options to separate file and categorize

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,102 +2,23 @@ import * as prettier from "prettier";
 import { BuiltInParserName } from "prettier";
 import { Beautifier, Language, BeautifierBeautifyData } from "unibeautify";
 
+import options from "./options";
 const pkg: object = require("../package.json");
 
 export const beautifier: Beautifier = {
   name: "Prettier",
   package: pkg,
   options: {
-    _: {
-      arrowParens: [
-        ["arrow_parens"],
-        (options): "avoid" | "always" => {
-          switch (options.arrow_parens) {
-            case "always":
-              return "always";
-            case "as-needed":
-              return "avoid";
-            default:
-              return "avoid";
-          }
-        }
-      ],
-      bracketSpacing: "object_curly_spacing",
-      insertPragma: "pragma_insert",
-      jsxBracketSameLine: "jsx_brackets",
-      printWidth: "wrap_line_length",
-      requirePragma: "pragma_require",
-      semi: "end_with_semicolon",
-      singleQuote: [
-        ["quotes"],
-        (options): boolean | undefined => {
-          switch (options.quotes) {
-            case "double":
-              return false;
-            case "single":
-              return true;
-            default:
-              return undefined;
-          }
-        }
-      ],
-      tabWidth: [
-        ["indent_with_tabs", "indent_size", "indent_char"],
-        (options): number => {
-          if (options.indent_with_tabs === true || options.indent_char === "\t") {
-            return 1;
-          } else {
-            return options.indent_size || 0;
-          }
-        }
-      ],
-      trailingComma: [
-        ["end_with_comma"],
-        (options): "none" | "es5" | "all" | undefined => {
-          switch (options.end_with_comma) {
-            case true:
-              return "es5";
-            case false:
-              return "none";
-            default:
-              return undefined;
-          }
-        }
-      ],
-      useTabs: [
-        ["indent_with_tabs", "indent_char"],
-        (options): boolean => {
-          if (options.indent_with_tabs === true) {
-            return true;
-          } else {
-            return options.indent_char === "\t";
-          }
-        }
-      ],
-    },
-    JavaScript: true,
-    JSX: true,
-    TypeScript: true,
-    CSS: true,
-    Less: true,
-    SCSS: true,
-    GraphQL: true,
-    JSON: true,
-    Vue: true,
-    Markdown: {
-      arrowParens: false,
-      bracketSpacing: false,
-      insertPragma: false,
-      jsxBracketSameLine: false,
-      requirePragma: false,
-      semi: false,
-      singleQuote: false,
-      trailingComma: false,
-      tabWidth: false,
-      useTabs: false,
-      printWidth: "wrap_line_length",
-      proseWrap: "wrap_prose",
-    }
+    CSS: options.Style,
+    GraphQL: options.Script,
+    JavaScript: options.Script,
+    JSON: options.Script,
+    JSX: options.Script,
+    Less: options.Style,
+    Markdown: options.Markdown,
+    SCSS: options.Style,
+    TypeScript: options.Script,
+    Vue: options.Script,
   },
   beautify(data: BeautifierBeautifyData) {
     return new Promise<string>((resolve, reject) => {

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,95 @@
+import { BeautifierOptions, OptionValues, BeautifierLanguageOptions } from "unibeautify";
+
+const commonOptions: BeautifierLanguageOptions = {
+  insertPragma: "pragma_insert",
+  printWidth: "wrap_line_length",
+  requirePragma: "pragma_require",
+  semi: "end_with_semicolon",
+  singleQuote: [
+    ["quotes"],
+    (options): boolean | undefined => {
+      switch (options.quotes) {
+        case "double":
+          return false;
+        case "single":
+          return true;
+        default:
+          return undefined;
+      }
+    }
+  ],
+  tabWidth: [
+    ["indent_with_tabs", "indent_size", "indent_char"],
+    (options): number => {
+      if (options.indent_with_tabs === true || options.indent_char === "\t") {
+        return 1;
+      } else {
+        return options.indent_size || 0;
+      }
+    }
+  ],
+  useTabs: [
+    ["indent_with_tabs", "indent_char"],
+    (options): boolean => {
+      if (options.indent_with_tabs === true) {
+        return true;
+      } else {
+        return options.indent_char === "\t";
+      }
+    }
+  ]
+};
+
+const markdownOptions: BeautifierLanguageOptions = {
+  ...commonOptions,
+  proseWrap: "wrap_prose"
+};
+
+const scriptOptions: BeautifierLanguageOptions = {
+  ...commonOptions,
+  arrowParens: [
+    ["arrow_parens"],
+    (options: OptionValues): "avoid" | "always" => {
+      switch (options.arrow_parens) {
+        case "always":
+          return "always";
+        case "as-needed":
+          return "avoid";
+        default:
+          return "avoid";
+      }
+    }
+  ],
+  bracketSpacing: "object_curly_spacing",
+  jsxBracketSameLine: "jsx_brackets",
+  trailingComma: [
+    ["end_with_comma"],
+    (options: OptionValues): "none" | "es5" | "all" | undefined => {
+      switch (options.end_with_comma) {
+        case true:
+          return "es5";
+        case false:
+          return "none";
+        default:
+          return undefined;
+      }
+    }
+  ],
+};
+
+const options = {
+  Markup: {
+    ...commonOptions
+  },
+  Markdown: {
+    ...markdownOptions
+  },
+  Script: {
+    ...scriptOptions
+  },
+  Style: {
+    ...commonOptions,
+  }
+};
+
+export default options;

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import { BeautifierOptions, OptionValues, BeautifierLanguageOptions } from "unibeautify";
+import { BeautifierOptions, OptionValues, BeautifierLanguageOptions, BeautifierLanguageOptionComplex } from "unibeautify";
 
 const commonOptions: BeautifierLanguageOptions = {
   insertPragma: "pragma_insert",
@@ -78,18 +78,10 @@ const scriptOptions: BeautifierLanguageOptions = {
 };
 
 const options = {
-  Markup: {
-    ...commonOptions
-  },
-  Markdown: {
-    ...markdownOptions
-  },
-  Script: {
-    ...scriptOptions
-  },
-  Style: {
-    ...commonOptions,
-  }
+  Markup: commonOptions,
+  Markdown: markdownOptions,
+  Script: scriptOptions,
+  Style: commonOptions
 };
 
 export default options;


### PR DESCRIPTION
I'm not crazy about how this was done.  I'd prefer to have the language-specific options directly in the options const, but having something like this errors out:

```
const options = {
  Markup: {
    ...commonOptions,
  },
  Markdown: {
    ...commonOptions,
  },
  Script: {
    ...commonOptions,
    bracketSpacing: "object_curly_spacing"  //Having this here causes the error
  },
  Style: {
    ...commonOptions,
  }
};
```

So instead made separate constants for [Markdown](https://github.com/Unibeautify/beautifier-prettier/blob/options-update/src/options.ts#L43-L46) and [Script](https://github.com/Unibeautify/beautifier-prettier/blob/options-update/src/options.ts#L48-L78) and put those constants in the [options](https://github.com/Unibeautify/beautifier-prettier/blob/options-update/src/options.ts#L80-L93) const