### PR TITLE
Update to indent_style, add more tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -580,12 +580,6 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
-    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -4822,12 +4816,11 @@
       "dev": true
     },
     "unibeautify": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/unibeautify/-/unibeautify-0.7.0.tgz",
-      "integrity": "sha512-SR4qAfYz2Q7xjOXgAR+cuZMdPlPfR8dp3OcgKqjI4PNRMVwkLX5uIMe7h9HG32f6LerIZPrJgfAKQWKgN+p7TQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/unibeautify/-/unibeautify-0.8.0.tgz",
+      "integrity": "sha512-zg0pYyWc1s9OK7uM8BeHhI0krHume4zgu6U42oztvROT03OxoqiQwHPrbA0rbo06Ja9GHMxEav9XGW2ZD4GbGQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
         "lodash": "4.17.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Unibeautify/beautifier-prettier#readme",
   "peerDependencies": {
-    "unibeautify": "^0.7.0",
+    "unibeautify": "^0.8.0",
     "prettier": "^1.10.2"
   },
   "devDependencies": {
@@ -43,6 +43,6 @@
     "tslint": "^5.7.0",
     "tslint-clean-code": "^0.2.3",
     "tslint-microsoft-contrib": "^5.0.1",
-    "unibeautify": "^0.7.0"
+    "unibeautify": "^0.8.0"
   }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -18,24 +18,14 @@ const commonOptions: BeautifierLanguageOptions = {
       }
     }
   ],
-  tabWidth: [
-    ["indent_with_tabs", "indent_size", "indent_char"],
-    (options): number => {
-      if (options.indent_with_tabs === true || options.indent_char === "\t") {
-        return 1;
-      } else {
-        return options.indent_size || 0;
-      }
-    }
-  ],
+  tabWidth: "indent_size",
   useTabs: [
-    ["indent_with_tabs", "indent_char"],
+    ["indent_style"],
     (options): boolean => {
-      if (options.indent_with_tabs === true) {
+      if (options.indent_style === "tab") {
         return true;
-      } else {
-        return options.indent_char === "\t";
       }
+      return false;
     }
   ]
 };

--- a/test/languages/GraphQL.spec.ts
+++ b/test/languages/GraphQL.spec.ts
@@ -22,7 +22,7 @@ tagline
       languageName: "GraphQL",
       options: {
         GraphQL: {
-          indent_char: " ",
+          indent_style: "space",
           indent_size: 2
         }
       },

--- a/test/languages/JSX.spec.ts
+++ b/test/languages/JSX.spec.ts
@@ -22,7 +22,7 @@ test("should successfully beautify JSX text", () => {
       languageName: "JSX",
       options: {
         JSX: {
-          indent_char: " ",
+          indent_style: "space",
           indent_size: 2
         }
       },

--- a/test/languages/JavaScript.spec.ts
+++ b/test/languages/JavaScript.spec.ts
@@ -16,7 +16,7 @@ test("should successfully beautify JavaScript text", () => {
       languageName: "JavaScript",
       options: {
         JavaScript: {
-          indent_char: " ",
+          indent_style: "space",
           indent_size: 2
         }
       },

--- a/test/languages/Unknown.spec.ts
+++ b/test/languages/Unknown.spec.ts
@@ -1,0 +1,29 @@
+import { newUnibeautify, Beautifier, Language } from "unibeautify";
+import beautifier from "../../src";
+import options from "../../src/options";
+test(`should fail to find a parser for the language`, () => {
+  const unibeautify = newUnibeautify();
+  const testLanguage: Language = {
+    atomGrammars: [],
+    extensions: ["test"],
+    name: "TestLanguage",
+    namespace: "test",
+    sublimeSyntaxes: [],
+    vscodeLanguages: []
+  };
+  unibeautify.loadLanguage(testLanguage);
+  const testBeautifier = {
+    ...beautifier,
+    options: {
+      [testLanguage.name]: true,
+    }
+  };
+  unibeautify.loadBeautifier(testBeautifier);
+  expect(unibeautify
+    .beautify({
+      languageName: testLanguage.name,
+      options: {},
+      text: "",
+    })
+  ).rejects.toThrowError(`Prettier Parser not found for langauge ${testLanguage.name}.`);
+});

--- a/test/languages/Vue.spec.ts
+++ b/test/languages/Vue.spec.ts
@@ -50,7 +50,7 @@ p {
       languageName: "Vue",
       options: {
         Vue: {
-          indent_char: " ",
+          indent_style: "space",
           indent_size: 2
         }
       },

--- a/test/options/arrowParens.spec.ts
+++ b/test/options/arrowParens.spec.ts
@@ -1,0 +1,30 @@
+import { newUnibeautify, Beautifier } from "unibeautify";
+import beautifier from "../../src";
+
+testArrowParens("always");
+testArrowParens("as-needed");
+
+function testArrowParens(arrowParens: string) {
+  test(`should successfully beautify JavaScript text with arrowParens=${arrowParens}`, () => {
+    const unibeautify = newUnibeautify();
+    unibeautify.loadBeautifier(beautifier);
+
+    const addArrowParens = arrowParens === "always";
+    const text = `a.then(${addArrowParens ? "foo" : "(foo)"} => {});\n`;
+    const beautifierResult = `a.then(${addArrowParens ? "(foo)" : "foo"} => {});\n`;
+
+    return unibeautify
+      .beautify({
+        languageName: "JavaScript",
+        options: {
+          JavaScript: {
+            arrow_parens: arrowParens
+          }
+        },
+        text
+      })
+      .then(results => {
+        expect(results).toBe(beautifierResult);
+      });
+  });
+}

--- a/test/options/printWidth.spec.ts
+++ b/test/options/printWidth.spec.ts
@@ -41,7 +41,7 @@ function beautifyWithPrintWidth(unibeautify: Unibeautify, text: string, printWid
     languageName: "JavaScript",
     options: {
       JavaScript: {
-        indent_char: " ",
+        indent_style: "space",
         indent_size: indentSize,
         end_with_comma: false,
         wrap_line_length: printWidth

--- a/test/options/quotes.spec.ts
+++ b/test/options/quotes.spec.ts
@@ -14,7 +14,7 @@ test(`should successfully beautify JavaScript text with single quotes`, () => {
       languageName: "JavaScript",
       options: {
         JavaScript: {
-          indent_char: " ",
+          indent_style: "space",
           indent_size: 2,
           quotes: "single"
         }
@@ -39,7 +39,7 @@ test(`should successfully beautify JavaScript text with double quotes`, () => {
       languageName: "JavaScript",
       options: {
         JavaScript: {
-          indent_char: " ",
+          indent_style: "space",
           indent_size: 2,
           quotes: "double"
         }

--- a/test/options/tabWidth.spec.ts
+++ b/test/options/tabWidth.spec.ts
@@ -17,6 +17,7 @@ function testWithTabWidth(tabWidth: number, useTabs: boolean = false) {
 
     const indentChar = useTabs ? "\t" : " ";
     const indentation = useTabs ? "\t" : indentChar.repeat(tabWidth);
+    const indentArg = useTabs ? "tab" : "space";
 
     const text = `function test(n){return n+1;}`;
     const beautifierResult = `function test(n) {
@@ -29,7 +30,7 @@ ${indentation}return n + 1;
         languageName: "JavaScript",
         options: {
           JavaScript: {
-            indent_char: indentChar,
+            indent_style: indentArg,
             indent_size: tabWidth
           }
         },

--- a/test/options/trailingComma.spec.ts
+++ b/test/options/trailingComma.spec.ts
@@ -20,7 +20,7 @@ function testWithTrailingComma(trailingComma: string) {
         languageName: "JavaScript",
         options: {
           JavaScript: {
-            indent_char: " ",
+            indent_style: "space",
             indent_size: 2,
             end_with_comma: endWithComma,
           }


### PR DESCRIPTION
* Updates options.ts to use indent_style instead of indent_char
* Updates tests to use indent_style instead of indent_char
* Adds two new tests for the arrowParens option and ensuring it throws an error when it's a language prettier doesn't support/recognize