### PR TITLE
fix: add singleQuote option back for stylesheets

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -92,12 +92,17 @@ const yamlOptions: BeautifierLanguageOptions = {
   singleQuote: scriptOptions.singleQuote,
 };
 
+const styleOptions: BeautifierLanguageOptions = {
+  ...commonOptions,
+  singleQuote: scriptOptions.singleQuote,
+};
+
 const options = {
   JSON: jsonOptions,
   Markup: commonOptions,
   Markdown: markdownOptions,
   Script: scriptOptions,
-  Style: commonOptions,
+  Style: styleOptions,
   GraphQL: commonOptions,
   Vue: vueOptions,
   YAML: yamlOptions,

--- a/test/options/quotes.spec.ts
+++ b/test/options/quotes.spec.ts
@@ -51,3 +51,54 @@ test(`should successfully beautify JavaScript text with double quotes`, () => {
       expect(results).toBe(beautifierResult);
     });
 });
+
+test(`should successfully beautify CSS text with single quotes`, () => {
+  const unibeautify = newUnibeautify();
+  unibeautify.loadBeautifier(beautifier);
+
+  const quote = "'";
+  const text = `p {\n  content: "hello";\n}`;
+  const beautifierResult = `p {\n  content: ${quote}hello${quote};\n}\n`;
+
+  return unibeautify
+    .beautify({
+      languageName: "CSS",
+      options: {
+        CSS: {
+          indent_style: "space",
+          indent_size: 2,
+          quotes: "single",
+        },
+      },
+      text,
+    })
+    .then(results => {
+      expect(results).toBe(beautifierResult);
+    });
+});
+
+test(`should successfully beautify CSS text with double quotes`, () => {
+  const unibeautify = newUnibeautify();
+  unibeautify.loadBeautifier(beautifier);
+
+  // unibeautify:ignore-next-line
+  const quote = '"';
+  const text = `p {\n  content: 'hello';\n}`;
+  const beautifierResult = `p {\n  content: ${quote}hello${quote};\n}\n`;
+
+  return unibeautify
+    .beautify({
+      languageName: "CSS",
+      options: {
+        CSS: {
+          indent_style: "space",
+          indent_size: 2,
+          quotes: "double",
+        },
+      },
+      text,
+    })
+    .then(results => {
+      expect(results).toBe(beautifierResult);
+    });
+});


### PR DESCRIPTION
Prettier supports this option for stylesheets, but this beautifier is not respecting the option.

[This commit](https://github.com/Unibeautify/beautifier-prettier/commit/659f08f3db4ad3d7accbeb53a4ab3a7787cf982e#diff-979382c1579c4f7d202d8be2d9adc712) removed the `singleQuote` option for Style files. The `singleQuote` option was removed from the `commonOptions` object. 

The goal of this PR was to add back the ability for the `singleQuote` option.

